### PR TITLE
Extended options in migration command

### DIFF
--- a/src/stubs/create.blade.stub
+++ b/src/stubs/create.blade.stub
@@ -1,4 +1,4 @@
-@extends('layouts.master')
+@extends('master')
 
 @section('content')
 

--- a/src/stubs/edit.blade.stub
+++ b/src/stubs/edit.blade.stub
@@ -1,4 +1,4 @@
-@extends('layouts.master')
+@extends('master')
 
 @section('content')
 

--- a/src/stubs/index.blade.stub
+++ b/src/stubs/index.blade.stub
@@ -1,4 +1,4 @@
-@extends('layouts.master')
+@extends('master')
 
 @section('content')
 

--- a/src/stubs/show.blade.stub
+++ b/src/stubs/show.blade.stub
@@ -1,4 +1,4 @@
-@extends('layouts.master')
+@extends('master')
 
 @section('content')
 


### PR DESCRIPTION
## Features
- Added ability to input multiple field options
- Added ability to add chained extenders (`nullable()`, `default()`, `unsigned()`)
- Added additional field type: `double`
- Limited to crud:migration basic command: Not currently integrated into full CRUD command
